### PR TITLE
Add LICENSE file.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2014 Karlos Fanta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
The README file of this project already mentions that contributions are welcome:

> You can also put it on the web (via CPanel or FTP) (for fun+AT OWN RISK), but preferably add password protection.
> Contributions/Comments are welcome!

I think, it has been mentioned in some other places, too. It seems, also, that there aren't any particular restrictions mentioned anywhere on usage or deployment, and the point has been made at several places within the codebase that the project is open source. But, there isn't yet any specific LICENSE file available for the project.

I propose the MIT License, since it's an open-source license, and similarly doesn't enforce any particular restrictions on usage or deployment, and includes some disclaimers for project authors and contributors.

> Copyright (c) 2014 Karlos Fanta

I'm unsure which date exactly you regard as the exact "birthdate" for the project, but seeing as the very first ever commit at this repository (12dc8805c29a8096d9943ff3961c7dd175e76bc1) was pushed 16 Oct 2014, I've marked 2014 as the copyright year provided by this pull request.